### PR TITLE
Chore: Add service.json to node service

### DIFF
--- a/node/index.ts
+++ b/node/index.ts
@@ -11,24 +11,21 @@ import { queries, mutations } from './resolvers'
 
 const TIMEOUT_MS = 10 * 1000
 
-// Create a LRU memory cache for the Status client.
 // The @vtex/api HttpClient respects Cache-Control headers and uses the provided cache.
 const memoryCache = new LRUCache<string, any>({ max: 5000 })
 
-metrics.trackCache('status', memoryCache)
+metrics.trackCache('checkout', memoryCache)
 
 // This is the configuration for clients available in `ctx.clients`.
 const clients: ClientsConfig<Clients> = {
-  // We pass our custom implementation of the clients bag, containing the Status client.
   implementation: Clients,
   options: {
     // All IO Clients will be initialized with these options, unless otherwise specified.
     default: {
       retries: 2,
       timeout: TIMEOUT_MS,
-    },
-    status: {
       memoryCache,
+      concurrency: 10,
     },
   },
 }

--- a/node/service.json
+++ b/node/service.json
@@ -1,0 +1,8 @@
+{
+  "stack": "nodejs",
+  "memory": 1024,
+  "ttl": 12,
+  "timeout": 10,
+  "minReplicas": 6,
+  "maxReplicas": 20
+}


### PR DESCRIPTION
This PR brings a `service.json` to the node application, as following the best practices found in other node apps.

I'm not sure how to measure the performance, but this branch is linked [here](https://performancebinding--powerplanet.myvtex.com).