### PR TITLE
Feat: Add active class when dropdown is open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added 
+- Add `active` class to css handles when dropdown is open.
 ## [1.2.1] - 2021-04-28
 
 ## [1.2.0] - 2021-03-30

--- a/docs/README.md
+++ b/docs/README.md
@@ -84,3 +84,6 @@ In order to apply CSS customizations in this and other blocks, follow the instru
 | `buttonText` |
 | `list` |
 | `listElement` |
+| `active*` |
+
+_*conditional class when dropdown is open_

--- a/node/package.json
+++ b/node/package.json
@@ -19,6 +19,6 @@
     "vtex.tenant-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.tenant-graphql@0.1.2/public/@types/vtex.tenant-graphql"
   },
   "dependencies": {
-    "@vtex/api": "6.41.0"
+    "@vtex/api": "6.42.1"
   }
 }

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1500,10 +1500,10 @@
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.2.tgz#808c9fa7e4517274ed555fa158f2de4b4f468e71"
   integrity sha512-HrCIVMLjE1MOozVoD86622S7aunluLb2PJdPfb3nYiEtohm8mIB/vyv0Fd37AdeMFrTUQXEunw78YloMA3Qilg==
 
-"@vtex/api@6.41.0":
-  version "6.41.0"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.41.0.tgz#cee074ff49de8a5de92f3d353a4689275cb92f7b"
-  integrity sha512-RvfdpczsxCFacZkDSl2v2NmfD/bHFxHHn2xQsEwSQ+40snGxfOz56TlCbPbgMEtkC8Bf+1GGUkCIChRE6xnlLg==
+"@vtex/api@6.42.1":
+  version "6.42.1"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.42.1.tgz#b0030afa16750f995bf8296bdc8b22ce2fa5907b"
+  integrity sha512-b9U+G1ZuZ6MOsbiLn+/FEW/XnTIGnsKam1YxUf7OHJhPY+ebupkxIhFeAWub/Mf8xELaNl+0EdrwUbuq4dNFxQ==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -1542,6 +1542,7 @@
     semver "^5.5.1"
     stats-lite vtex/node-stats-lite#dist
     tar-fs "^2.0.0"
+    tokenbucket "^0.3.2"
     uuid "^3.3.3"
     xss "^1.0.6"
 
@@ -2030,6 +2031,11 @@ bl@^4.0.3:
     buffer "^5.5.0"
     inherits "^2.0.4"
     readable-stream "^3.4.0"
+
+bluebird@2.9.24:
+  version "2.9.24"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-2.9.24.tgz#14a2e75f0548323dc35aa440d92007ca154e967c"
+  integrity sha1-FKLnXwVIMj3DWqRA2SAHyhVOlnw=
 
 bluebird@^3.5.4:
   version "3.7.2"
@@ -4928,6 +4934,11 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
+redis@^0.12.1:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/redis/-/redis-0.12.1.tgz#64df76ad0fc8acebaebd2a0645e8a48fac49185e"
+  integrity sha1-ZN92rQ/IrOuuvSoGReikj6xJGF4=
+
 regenerate-unicode-properties@^8.2.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-8.2.0.tgz#e5de7111d655e7ba60c057dbe9ff37c87e65cdec"
@@ -5384,7 +5395,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:
@@ -5614,6 +5625,14 @@ toidentifier@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
+
+tokenbucket@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/tokenbucket/-/tokenbucket-0.3.2.tgz#8172b2b58e3083acc8d914426fed15162a3a8e90"
+  integrity sha1-gXKytY4wg6zI2RRCb+0VFio6jpA=
+  dependencies:
+    bluebird "2.9.24"
+    redis "^0.12.1"
 
 tough-cookie@^2.3.3, tough-cookie@~2.5.0:
   version "2.5.0"

--- a/react/BindingSelectorBlock.tsx
+++ b/react/BindingSelectorBlock.tsx
@@ -19,6 +19,7 @@ const CSS_HANDLES = [
   'relativeContainer',
   'button',
   'buttonText',
+  'active',
 ] as const
 
 interface GetOrderFormResponse {
@@ -222,7 +223,9 @@ const BindingSelectorBlock: FC = () => {
 
   return hasError ? null : (
     <div
-      className={`${handles.container} flex items-center justify-center w3 relative`}
+      className={`${handles.container} ${
+        open ? handles.active : ''
+      } flex items-center justify-center w3 relative`}
     >
       <div
         ref={relativeContainer}


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->
This PR adds `vtex-binding-selector-1-x-active` as a class to binding selector container when the dropdown is open.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->
In this [workspace](https://bindingselectoractivecss--powerplanet.myvtex.com/), inspect the tag container for binding selector. It should include the class `vtex-binding-selector-1-x-active` only when the dropdown is open.

#### Screenshots or example usage:

_Dropdown close_
<img width="1438" alt="Screen Shot 2021-05-25 at 4 25 01 PM" src="https://user-images.githubusercontent.com/38737958/119516996-82507180-bd77-11eb-9392-294d63ae491b.png">

_Dropdown open_
<img width="1440" alt="Screen Shot 2021-05-25 at 4 39 08 PM" src="https://user-images.githubusercontent.com/38737958/119517419-e3784500-bd77-11eb-8a55-628b3ffbe72b.png">
