### PR TITLE
Fix update default values for tenant information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Issue keeping old information into configuration. It now updates `canonicalBaseAddress`, `salesChannel` and `defaultLocale` based on information coming from `tenant` app every time user saves new information inside `costumize store name`.
+
 ## [1.3.0] - 2021-05-26
 
 ### Added

--- a/react/utils/index.ts
+++ b/react/utils/index.ts
@@ -186,24 +186,30 @@ export const createBindingsToLabel = (
   bindings: Binding[],
   currentTranslations: BindingTranslation[]
 ): Record<string, BindingTranslation> => {
-  const translationsMap: Record<string, BindingTranslation> = {}
+  const translationsMap: Record<string, Partial<BindingTranslation>> = {}
 
   for (const translation of currentTranslations) {
     translationsMap[translation.id] = {
       id: translation.id,
       label: translation.label,
-      salesChannel: translation.salesChannel,
-      defaultLocale: translation.defaultLocale,
-      canonicalBaseAddress: translation.canonicalBaseAddress,
-      hide: translation.hide,
+      hide: !!translation.hide,
     }
   }
 
   return bindings.reduce((map, binding) => {
+    const staticInfo = {
+      canonicalBaseAddress: binding.canonicalBaseAddress,
+      salesChannel: String(binding.extraContext.portal.salesChannel),
+      defaultLocale: binding.defaultLocale,
+    }
+
     if (translationsMap[binding.id]) {
       return {
         ...map,
-        [binding.id]: translationsMap[binding.id],
+        [binding.id]: {
+          ...translationsMap[binding.id],
+          ...staticInfo,
+        },
       }
     }
 
@@ -212,10 +218,8 @@ export const createBindingsToLabel = (
       [binding.id]: {
         id: binding.id,
         label: '',
-        salesChannel: '',
-        defaultLocale: '',
-        canonicalBaseAddress: '',
         hide: false,
+        ...staticInfo,
       },
     }
   }, {})


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->
This PR fixes a bug preventing changes on tenant to be updated in the binding selector configuration. The fixed values that will be updated every time user saves new custom info are `canonicalBaseAddress`, `salesChannel` and `defaultLocale`.

With that, every new change in any of the above variables, admin user will have to open all the `customize store name` and hit save.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->
In this [workspace](https://bindingselectorfix--smartcsb2c.myvtex.com/admin/binding-selector), open the `customize store name` modal for a binding and than hit save. Go to [GraphQL IDE](https://bindingselectorfix--smartcsb2c.myvtex.com/admin/graphql-ide) and perform the following query in the linked `binding-selector` app:

```graphql
{
    bindingInfo {
        translatedLocales {
            canonicalBaseAddress
        }
    }
}
```

You should see the current `canonicalBaseAddress` in the binding you just saved.

_Warning_
The redirects on the home page will only be fully working when we open and save all `customize store name`. We can think about a better approach for this in the future.

_Warning 2_
Since master is overwritten VBase on workspace level, we can see some weird behavior if someone is working on master.
