### PR TITLE
Fix: Change way to query binding info to avoid cache problem

### DIFF
--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -1,6 +1,7 @@
 type Query {
-  bindingInfo: [TranslatedInfoOutput] @cacheControl(scope: PUBLIC)
-  isSalesChannelUpdate: Boolean @cacheControl(scope: PUBLIC)
+  bindingInfo: [TranslatedInfoOutput]
+    @cacheControl(scope: PUBLIC, maxAge: SHORT)
+  isSalesChannelUpdate: Boolean @cacheControl(scope: PUBLIC, maxAge: SHORT)
 }
 
 type Mutation {

--- a/react/BindingSelectorBlock.tsx
+++ b/react/BindingSelectorBlock.tsx
@@ -81,7 +81,10 @@ const BindingSelectorBlock: FC = () => {
   const [loadingRedirect, setLoadingRedirect] = useState<boolean>(false)
 
   const { data: toogleSalesChannel } = useQuery<SalesChannelResponse>(
-    shouldUpdateSalesChannel
+    shouldUpdateSalesChannel,
+    {
+      ssr: false,
+    }
   )
 
   const relativeContainer = useRef<HTMLDivElement | null>(null)
@@ -101,12 +104,16 @@ const BindingSelectorBlock: FC = () => {
 
       path = getMatchRoute({ routes, currentBindingId: currentBinding.id })
 
-      window.location.href = createRedirectUrl({
+      const urlToRedirect = createRedirectUrl({
         canonicalBaseAddress,
         hostname,
         protocol,
         path,
       })
+
+      console.info(`Redirecting to ${urlToRedirect}`)
+
+      window.location.href = urlToRedirect
     }
   }, [hrefAltData, currentBinding])
 

--- a/react/hooks/useBindings.ts
+++ b/react/hooks/useBindings.ts
@@ -16,7 +16,9 @@ export const useBinding = () => {
     data: bindingData,
     loading: loadingBindings,
     error: bindingsError,
-  } = useQuery<BindingInfoResponse>(getBindingInfo)
+  } = useQuery<BindingInfoResponse>(getBindingInfo, {
+    ssr: false,
+  })
 
   const { binding: runtimeBinding } = useRuntime()
 


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->
This PR is an attempt to fix the error on AmetllerOrigen. As now, the query to get the canonical used to build the URL user is redirect after selecting a new binding, brings a `/`, causing the final URL to have two `/` between canonical and URL path, something like `https://www.ametllerorigen.com/ca//plats-cuinats/sopes-i-gaspatxos`.

Recently, we removed from the canonical the trailing /, and we can see that the information on VBase is up to date. However, the master env on Ametller is still using the cached version.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[This workspace](https://fila--ametllerorigen.myvtex.com) has this branch linked. The binding selector should be working as expected, e.g. redirecting user inside a product page to the target binding without taking them to homepage (if alternate is register).
