### PR TITLE
My account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Allow changing bindings from `my account` page.
+
 ## [1.3.2] - 2021-06-18
 
 ## [1.3.1] - 2021-05-27

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "binding-selector",
   "vendor": "vtex",
-  "version": "1.3.3-beta.1",
+  "version": "1.3.3-beta.2",
   "title": "Binding Selector App",
   "description": "",
   "mustUpdateAt": "2022-08-28",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "binding-selector",
   "vendor": "vtex",
-  "version": "1.3.2",
+  "version": "1.3.3-beta.0",
   "title": "Binding Selector App",
   "description": "",
   "mustUpdateAt": "2022-08-28",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "binding-selector",
   "vendor": "vtex",
-  "version": "1.3.3-beta.0",
+  "version": "1.3.3-beta.1",
   "title": "Binding Selector App",
   "description": "",
   "mustUpdateAt": "2022-08-28",

--- a/node/package.json
+++ b/node/package.json
@@ -19,6 +19,6 @@
     "vtex.tenant-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.tenant-graphql@0.1.2/public/@types/vtex.tenant-graphql"
   },
   "dependencies": {
-    "@vtex/api": "6.42.1"
+    "@vtex/api": "6.43.0"
   }
 }

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1500,10 +1500,10 @@
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.2.tgz#808c9fa7e4517274ed555fa158f2de4b4f468e71"
   integrity sha512-HrCIVMLjE1MOozVoD86622S7aunluLb2PJdPfb3nYiEtohm8mIB/vyv0Fd37AdeMFrTUQXEunw78YloMA3Qilg==
 
-"@vtex/api@6.42.1":
-  version "6.42.1"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.42.1.tgz#b0030afa16750f995bf8296bdc8b22ce2fa5907b"
-  integrity sha512-b9U+G1ZuZ6MOsbiLn+/FEW/XnTIGnsKam1YxUf7OHJhPY+ebupkxIhFeAWub/Mf8xELaNl+0EdrwUbuq4dNFxQ==
+"@vtex/api@6.43.0":
+  version "6.43.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.43.0.tgz#f84ce6dcfcc96e3be5d6917437e21b66a1a7d267"
+  integrity sha512-NF2+x7XFE9D31oUb3U2i9UIZtakUKGAZKfRPYwdSpMQZits4wpL4jBcnjwX7Bufl9lZx3GfnLm0LabLI7vjAOw==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"

--- a/react/BindingSelectorBlock.tsx
+++ b/react/BindingSelectorBlock.tsx
@@ -95,7 +95,13 @@ const BindingSelectorBlock: FC = () => {
    */
   useEffect(() => {
     const { canonicalBaseAddress } = currentBinding
-    const { hostname, protocol } = window.location
+    const {
+      hostname,
+      protocol,
+      hash,
+      pathname: locationPathname,
+    } = window.location
+
     let path = ''
 
     // eslint-disable-next-line vtex/prefer-early-return
@@ -109,6 +115,8 @@ const BindingSelectorBlock: FC = () => {
         hostname,
         protocol,
         path,
+        hash,
+        locationPathname,
       })
 
       console.info(`Redirecting to ${urlToRedirect}`)

--- a/react/BindingSelectorBlock.tsx
+++ b/react/BindingSelectorBlock.tsx
@@ -95,13 +95,7 @@ const BindingSelectorBlock: FC = () => {
    */
   useEffect(() => {
     const { canonicalBaseAddress } = currentBinding
-    const {
-      hostname,
-      protocol,
-      hash,
-      pathname: locationPathname,
-    } = window.location
-
+    const { hostname, protocol, hash } = window.location
     let path = ''
 
     // eslint-disable-next-line vtex/prefer-early-return
@@ -116,14 +110,14 @@ const BindingSelectorBlock: FC = () => {
         protocol,
         path,
         hash,
-        locationPathname,
+        pageType: id,
       })
 
       console.info(`Redirecting to ${urlToRedirect}`)
 
       window.location.href = urlToRedirect
     }
-  }, [hrefAltData, currentBinding])
+  }, [hrefAltData, currentBinding, id])
 
   /**
    * This effect handles the synchronization between binding sales channel on page load and cart sales channel.

--- a/react/utils/index.ts
+++ b/react/utils/index.ts
@@ -110,11 +110,11 @@ interface RedirectUrlArgs {
   protocol: Window['location']['protocol']
   path: string
   hash: string
-  locationPathname: string
+  pageType: string
 }
 
-export const isMyAccount = (pathname: string): boolean =>
-  pathname.indexOf('/account') !== -1
+export const isMyAccount = (pageType: string): boolean =>
+  pageType === 'store.account'
 
 export const createRedirectUrl = ({
   canonicalBaseAddress,
@@ -122,12 +122,12 @@ export const createRedirectUrl = ({
   protocol,
   path,
   hash,
-  locationPathname,
+  pageType,
 }: RedirectUrlArgs): string => {
   const queryString = `?__bindingAddress=${canonicalBaseAddress}`
   const isMyVtex = hostname.indexOf('myvtex') !== -1
 
-  const myAccount = isMyAccount(locationPathname)
+  const myAccount = isMyAccount(pageType)
 
   return `${protocol}//${isMyVtex ? hostname : canonicalBaseAddress}${
     !myAccount ? path : '/account'

--- a/react/utils/index.ts
+++ b/react/utils/index.ts
@@ -130,7 +130,7 @@ export const createRedirectUrl = ({
   const myAccount = isMyAccount(locationPathname)
 
   return `${protocol}//${isMyVtex ? hostname : canonicalBaseAddress}${
-    !myAccount ? path : locationPathname
+    !myAccount ? path : '/account'
   }${isMyVtex ? queryString : ''}${hash}`
 }
 

--- a/react/utils/index.ts
+++ b/react/utils/index.ts
@@ -109,20 +109,29 @@ interface RedirectUrlArgs {
   hostname: Window['location']['hostname']
   protocol: Window['location']['protocol']
   path: string
+  hash: string
+  locationPathname: string
 }
+
+export const isMyAccount = (pathname: string): boolean =>
+  pathname.indexOf('/account') !== -1
 
 export const createRedirectUrl = ({
   canonicalBaseAddress,
   hostname,
   protocol,
   path,
+  hash,
+  locationPathname,
 }: RedirectUrlArgs): string => {
   const queryString = `?__bindingAddress=${canonicalBaseAddress}`
   const isMyVtex = hostname.indexOf('myvtex') !== -1
 
-  return `${protocol}//${isMyVtex ? hostname : canonicalBaseAddress}${path}${
-    isMyVtex ? queryString : ''
-  }`
+  const myAccount = isMyAccount(locationPathname)
+
+  return `${protocol}//${isMyVtex ? hostname : canonicalBaseAddress}${
+    !myAccount ? path : locationPathname
+  }${isMyVtex ? queryString : ''}${hash}`
 }
 
 interface MatchRoute {


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->
This code allows the `binding selector app` to be used in `My Account`page. The solution relies on `pageContext` `type`. When it's equal `store.account`, it ignores the result from the query to get the alternate hrefs, and build the URL ro redirect the user to `/account` and the current `hash` on `window.location`.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->
The app is running in [this workspace](https://bindselmyaccount--powerplanet.myvtex.com) and also installed on [master](https://www.testperformancev.com/).

Visit either one and then log in. Inside the my account section, changes the binding using the binding selector and you should be redirect to the same page you are in right now.

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->
![recording (2)](https://user-images.githubusercontent.com/38737958/123665480-9e44a880-d838-11eb-9af3-1864e1d4ea12.gif)

