### PR TITLE
new orderform query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Changed
+- Swapped the orderForm query for the Order Manager's hook
 ## [1.4.0] - 2021-10-05
 
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -17,7 +17,8 @@
     "vtex.order-manager": "0.x",
     "vtex.order-items": "0.x",
     "vtex.checkout-graphql": "0.x",
-    "vtex.store-graphql": "2.x"
+    "vtex.store-graphql": "2.x",
+    "vtex.session-client": "1.x"
   },
   "builders": {
     "react": "3.x",

--- a/node/package.json
+++ b/node/package.json
@@ -19,6 +19,6 @@
     "vtex.tenant-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.tenant-graphql@0.1.2/public/@types/vtex.tenant-graphql"
   },
   "dependencies": {
-    "@vtex/api": "6.45.4"
+    "@vtex/api": "6.45.6"
   }
 }

--- a/node/service.json
+++ b/node/service.json
@@ -1,7 +1,7 @@
 {
   "stack": "nodejs",
   "memory": 1024,
-  "ttl": 12,
+  "ttl": 60,
   "timeout": 10,
   "minReplicas": 6,
   "maxReplicas": 20

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1500,10 +1500,10 @@
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.2.tgz#808c9fa7e4517274ed555fa158f2de4b4f468e71"
   integrity sha512-HrCIVMLjE1MOozVoD86622S7aunluLb2PJdPfb3nYiEtohm8mIB/vyv0Fd37AdeMFrTUQXEunw78YloMA3Qilg==
 
-"@vtex/api@6.45.4":
-  version "6.45.4"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.4.tgz#58be7497c0c0f91a388fabd42149e48cb95e271d"
-  integrity sha512-DVAJr5BkSjXupjn2h5Z1In8C3Li9kZwCXPwRQbpIgyS7s9dN2ZEFQc6nQlJm6ZoDCoyYBg62LgD7Kurvz9jc3w==
+"@vtex/api@6.45.6":
+  version "6.45.6"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.6.tgz#e5f08476d7c76f26baa1c040666d1364bdd6bc35"
+  integrity sha512-9pDiUxcUzq8RZa9yBex4C8dcAHXBRGAZokvHJ6sykrojq6mJxs+rUTE28TPeeQxwvvKsvrdpsfCUAYQ+UDz+zA==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"

--- a/react/graphql/getOrderForm.gql
+++ b/react/graphql/getOrderForm.gql
@@ -1,9 +1,0 @@
-query getOrderForm {
-  orderForm @context(provider: "vtex.store-graphql") {
-    salesChannel
-    orderFormId
-    items {
-      id
-    }
-  }
-}


### PR DESCRIPTION
#### What problem is this solving?

The original query was only firing when the component rendered, so the binding selector would wait for its parents, and then itself, to be rendered before fetching the orderform; causing a perceived slowness. The order-manager already posses the reference to an up to date orderform, so I swapped the implementation.

** EDIT **
The orderform hook doesn't have the sales channel (big oversight from the checkout-graphql app)
So I used the render session hook for this value

#### How to test it?

[Workspace](https://neworderformquery--powerplanet.myvtex.com)

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/M3fYVlu7YN9Hq/giphy.gif)
