### PR TITLE
Remove trailing forward slash from redirect url

### DIFF
--- a/react/utils/index.ts
+++ b/react/utils/index.ts
@@ -166,9 +166,9 @@ export const createRedirectUrl = ({
     isMyVtex,
   })
 
-  return `${protocol}//${isMyVtex ? hostname : canonicalBaseAddress}${
-    !myAccount ? path : '/account'
-  }${queryString}${hash}`
+  return `${protocol}//${
+    isMyVtex ? hostname : canonicalBaseAddress.replace(/\/$/, '')
+  }${!myAccount ? path : '/account'}${queryString}${hash}`
 }
 
 interface MatchRoute {


### PR DESCRIPTION
#### What problem is this solving?

If a canonical address posses a trailing forward slash it could break the redirect as it would build the URL with duplicated forward slashes i.e: `https://en.floria.ro//gifts/special-gifts`

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://sanz--floriaro.myvtex.com/cadouri/speciale)
Change binding, you'll properly get redirected