### PR TITLE
Redirect current page

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -60,7 +60,8 @@ The Setup for the app is as follows:
      "binding-selector": {
        "props": {
          "layout": "dropdown",
-         "display": "text"
+         "display": "text",
+         "redirectPage: "home"
        }
      }
    }
@@ -95,6 +96,9 @@ Renders a component that allows the user to select a different binding for your 
 | --------- | -------- | ---------------------------------------------------------------------------------------------- | ------------- |
 | `layout`  | `string` | How the bindings are grouped. Possible values are: `dropdown` - `list` - `select`            | `dropdown`    |
 | `display` | `string` | How the bindings are displayed in the group. Possible values are: `text` - `flag` - `combined`. Please keep in mind that the `select` layout cannot be paired with `flag` or `combined`, as the native HTML tag 'select' can only render text | `text`        |
+| `redirectPage`  | `string` | To which page will redirect after. `home` will redirect to the home page. `current` will redirect to the current page you are. Possible values are: `home` - `current`            | `home`    |
+
+
 
 ### `current-binding` block
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "binding-selector",
   "vendor": "vtex",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "title": "Binding Selector App",
   "description": "",
   "mustUpdateAt": "2022-08-28",

--- a/node/package.json
+++ b/node/package.json
@@ -24,6 +24,6 @@
     "vtex.tenant-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.tenant-graphql@0.1.2/public/@types/vtex.tenant-graphql"
   },
   "dependencies": {
-    "@vtex/api": "6.45.6"
+    "@vtex/api": "6.45.13"
   }
 }

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1500,10 +1500,10 @@
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.2.tgz#808c9fa7e4517274ed555fa158f2de4b4f468e71"
   integrity sha512-HrCIVMLjE1MOozVoD86622S7aunluLb2PJdPfb3nYiEtohm8mIB/vyv0Fd37AdeMFrTUQXEunw78YloMA3Qilg==
 
-"@vtex/api@6.45.6":
-  version "6.45.6"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.6.tgz#e5f08476d7c76f26baa1c040666d1364bdd6bc35"
-  integrity sha512-9pDiUxcUzq8RZa9yBex4C8dcAHXBRGAZokvHJ6sykrojq6mJxs+rUTE28TPeeQxwvvKsvrdpsfCUAYQ+UDz+zA==
+"@vtex/api@6.45.13":
+  version "6.45.13"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.13.tgz#836c392fa9567009e34559f08698f6efc95e88cc"
+  integrity sha512-P22/ObNdsgLvagetcDrovFfSXHe8Jb4yHud4U0rXHfIYEIMSnEdQ/QHujF3CEa5AiZnvbR/5W5ynGtWHYHOv9A==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -5381,7 +5381,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:

--- a/react/BindingChallenge.tsx
+++ b/react/BindingChallenge.tsx
@@ -97,7 +97,7 @@ const BindingChallenge = ({ barText }: Props) => {
       </span>
       <div className={`${handles.actionContainer} flex`}>
         <span className="mh5 w-10" style={{ width: 180 }}>
-          <BindingSelectorBlock layout="select" display="text" />
+          <BindingSelectorBlock layout="select" display="text" redirectPage="home"/>
         </span>
         <span>
           <ButtonWithIcon

--- a/react/BindingSelectorBlock.tsx
+++ b/react/BindingSelectorBlock.tsx
@@ -27,11 +27,13 @@ interface Props {
   layout: 'dropwdown' | 'list' | 'select'
   /* How we display each binding */
   display: FlagDisplay
+  redirectPage: 'home' | 'current'
 }
 
 const BindingSelectorBlock: FC<Props> = ({
   layout = 'dropdown',
   display = 'text',
+  redirectPage = 'home',
 }) => {
   const {
     data: { currentBinding, bindingList, bindingsError, loadingBindings },
@@ -99,9 +101,8 @@ const BindingSelectorBlock: FC<Props> = ({
    */
   useEffect(() => {
     const { canonicalBaseAddress } = currentBinding
-    const { hostname, protocol, hash } = window.location
+    const { hostname, protocol, hash, pathname } = window.location
     let path = ''
-
     // eslint-disable-next-line vtex/prefer-early-return
     if (hrefAltData) {
       const { routes = [] } = hrefAltData.internal
@@ -126,8 +127,8 @@ const BindingSelectorBlock: FC<Props> = ({
          * See more details in the useEffect below.
          */
         salesChannel: salesChannel || channel,
+        currentPage: redirectPage === 'current' ? pathname : '',
       })
-
       console.info(`Redirecting to ${urlToRedirect}`)
 
       window.location.href = urlToRedirect

--- a/react/utils/index.ts
+++ b/react/utils/index.ts
@@ -146,6 +146,7 @@ interface RedirectUrlArgs {
   pageType: string
   keepSalesChannel?: boolean
   salesChannel?: string
+  currentPage?: string
 }
 
 export const isMyAccount = (pageType: string): boolean =>
@@ -160,6 +161,7 @@ export const createRedirectUrl = ({
   pageType,
   keepSalesChannel = false,
   salesChannel,
+  currentPage,
 }: RedirectUrlArgs): string => {
   const isMyVtex = hostname.indexOf('myvtex') !== -1
 
@@ -172,9 +174,7 @@ export const createRedirectUrl = ({
     isMyVtex,
   })
 
-  return `${protocol}//${
-    isMyVtex ? hostname : canonicalBaseAddress.replace(/\/$/, '')
-  }${!myAccount ? path : '/account'}${queryString}${hash}`
+  return `${protocol}//${isMyVtex ? hostname : canonicalBaseAddress.replace(/\/$/, '')}${currentPage ? currentPage : ""}${!myAccount ? path : '/account'}${queryString}${hash}`
 }
 
 interface MatchRoute {


### PR DESCRIPTION
#### What problem is this solving?

When you use the bindigs selector always redirects to the home after change the bindig.

We add the `redirectPage` to enable to redirect to the current page you are using.

#### How to test it?

[Workspace](https://gbo--beautycounterqa.myvtex.com/)

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/55905671/210247430-c897204b-fd59-4ca3-9e71-244b0d2b9750.png)
![image](https://user-images.githubusercontent.com/55905671/210247442-0a05bbd1-6b91-4738-b3b6-4d450c85e66a.png)

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/3NtY188QaxDdC/giphy.gif)
