### PR TITLE
fix english translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- English translation
+
 ## [2.1.2] - 2022-02-17
 ### Added
 - `dropdown` can now render flags

--- a/messages/en.json
+++ b/messages/en.json
@@ -3,7 +3,7 @@
   "admin-binding-selector": "Binding Selector",
   "admin-binding-selector.navigation.search.kws": "Binding Selector",
   "admin-description": "The sales policies will be updated when your customers change their store bindings.",
-  "admin-label": "Update Sales Channel",
+  "admin-label": "Update Trade Policy",
   "admin-store": "Store {index}: {address}",
   "admin-locale": "Locale: {locale}",
   "admin-action": "Custom store names",


### PR DESCRIPTION
#### What problem is this solving?

Fix English translation.

We are patterning Sales Channels labels as Trade Policies for all Admin content.
