### PR TITLE
Fix old translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Portuguese, Spanish and Italian translations.
+
 ## [2.1.4] - 2023-06-28
 
 ### Fixed

--- a/messages/context.json
+++ b/messages/context.json
@@ -3,7 +3,7 @@
   "admin/binding-selector": "Binding Selector",
   "admin/binding-selector.navigation.search.kws": "Binding Selector",
   "admin/description": "The sales policies will be updated when your customers change their store bindings.",
-  "admin/label": "Update Sales Channel",
+  "admin/label": "Update Trade Policy",
   "admin/store": "Store {index}: {address}",
   "admin/locale": "Locale: {locale}",
   "admin/action": "Custom store names",

--- a/messages/es.json
+++ b/messages/es.json
@@ -3,7 +3,7 @@
   "admin/binding-selector": "Selector de binding",
   "admin/binding-selector.navigation.search.kws": "Selector de binding",
   "admin/description": "Las políticas comerciales se actualizarán cuando tus clientes cambien los bindings de su tienda.",
-  "admin/label": "Actualizar canal de ventas",
+  "admin/label": "Actualizar política comercial",
   "admin/store": "Tienda {index}: {address}",
   "admin/locale": "Región: {locale}",
   "admin/action": "Nombres de tienda personalizados",

--- a/messages/it.json
+++ b/messages/it.json
@@ -3,7 +3,7 @@
   "admin/binding-selector": "Selettore di binding",
   "admin/binding-selector.navigation.search.kws": "Selettore di binding",
   "admin/description": "Le politiche di vendita verranno aggiornate quando i tuoi clienti cambieranno i binding dei negozi.",
-  "admin/label": "Aggiorna canali di vendita",
+  "admin/label": "Aggiorna politica commerciale",
   "admin/store": "Negozio {index}: {address}",
   "admin/locale": "Regione: {locale}",
   "admin/action": "Personalizza i nomi del negozio",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -3,7 +3,7 @@
   "admin/binding-selector": "Seletor de binding",
   "admin/binding-selector.navigation.search.kws": "Seletor de binding",
   "admin/description": "As políticas de vendas serão atualizadas quando seus clientes mudarem os bindings de suas lojas.",
-  "admin/label": "Atualizar canal de vendas",
+  "admin/label": "Atualizar política comercial",
   "admin/store": "Loja {index}: {address}",
   "admin/locale": "Região: {locale}",
   "admin/action": "Nomes das lojas personalizadas",


### PR DESCRIPTION
Fix Spanish, Italian and Portuguese translations. Tracked in task [LOC-11986](https://vtex-dev.atlassian.net/browse/LOC-11986).

[LOC-11986]: https://vtex-dev.atlassian.net/browse/LOC-11986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ