### PR TITLE
Update README.md - change in the dependency type (peerDependencies) a…

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -28,11 +28,11 @@ The App consists on **two** main features an **Admin Interface** and a Store Blo
 The Setup for the app is as follows:
 
 1. on the CLI and run: `vtex install vtex.binding-selector@2.x`
-2. declare the block as a dependency inside your store-theme:
+2. declare the block as a peerDependency inside your store-theme manifest.json:
 
    ```
-   "dependencies":{
-     "vtex.binding-selector":"2.x"
+   "peerDependencies": {
+    "vtex.reviews-and-ratings": "3.x"
    }
    ```
 
@@ -40,29 +40,28 @@ The Setup for the app is as follows:
 
    ```
    "flex-layout.row#4-desktop": {
-     "props": {
-       "blockClass": "main-header",
-       "horizontalAlign": "center",
-       "verticalAlign": "center",
-       "preventHorizontalStretch": true,
-       "preventVerticalStretch": true,
-       "fullWidth": true
-     },
-     "children": [
-       "flex-layout.col#logo-desktop",
-       "flex-layout.col#category-menu",
-       "flex-layout.col#spacer",
-       "search-bar",
-       "binding-selector",
-       "login",
-       "minicart.v2"
-     ],
-     "binding-selector": {
-       "props": {
-         "layout": "dropdown",
-         "display": "text"
-       }
-     }
+    "props": {
+      "blockClass": "main-header",
+      "horizontalAlign": "center",
+      "verticalAlign": "center",
+      "preventHorizontalStretch": true,
+      "preventVerticalStretch": true,
+      "fullWidth": true
+    },
+    "children": [
+      "flex-layout.col#logo-desktop",
+      "flex-layout.col#category-menu",
+      "flex-layout.col#spacer",
+      "search-bar",
+      "binding-selector",
+      "login",
+      "minicart.v2"
+    ]},
+   "binding-selector": {
+    "props": {
+      "layout": "dropdown",
+      "display": "combined"
+    }
    }
 
    ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,7 +32,7 @@ The Setup for the app is as follows:
 
    ```
    "peerDependencies": {
-    "vtex.reviews-and-ratings": "3.x"
+    "vtex.binding-selector": "2.x"
    }
    ```
 


### PR DESCRIPTION
…nd in the the example of the header.json bloc

There are 2 main changes to the README:

1. The "vtex.binding-selector": "2.x" app should be declared in the manifest.json as a peerDependency not as a Dependency, otherwise the following error would occur: Error with dependency vtex.binding-selector@2.x: App cannot contain billing options: vtex.binding-selector@2.x

2. The header.json code example is wrong. The way as it is right now the binding-selector block is being called inside the flex-layout.row#4-desktop block and with that the following error occur: Unsupported field `binding-selector` declared by `flex-layout.row#4-desktop`. Blocks should declare only `parent`, `props`, `render`, `title`, `children`, and `blocks`

The corrected version declares it outside of this block, preventing this error.

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](Link goes here!)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
