### PR TITLE
Update terminology from trade policy to sales channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Update terms from "Trade Policy" to "Sales Channel"
+
 ## [2.1.7] - 2024-04-25
 
 ## [2.1.6] - 2024-02-13

--- a/messages/context.json
+++ b/messages/context.json
@@ -3,7 +3,7 @@
   "admin/binding-selector": "Binding Selector",
   "admin/binding-selector.navigation.search.kws": "Binding Selector",
   "admin/description": "The sales policies will be updated when your customers change their store bindings.",
-  "admin/label": "Update Trade Policy",
+  "admin/label": "Update sales channel",
   "admin/store": "Store {index}: {address}",
   "admin/locale": "Locale: {locale}",
   "admin/action": "Custom store names",

--- a/messages/en.json
+++ b/messages/en.json
@@ -3,7 +3,7 @@
   "admin/binding-selector": "Binding Selector",
   "admin/binding-selector.navigation.search.kws": "Binding Selector",
   "admin/description": "The sales policies will be updated when your customers change their store bindings.",
-  "admin/label": "Update Trade Policy",
+  "admin/label": "Update sales channel",
   "admin/store": "Store {index}: {address}",
   "admin/locale": "Locale: {locale}",
   "admin/action": "Custom store names",


### PR DESCRIPTION
Update terminology from trade policy to sales channel. Tracked in task [LOC-22226](https://vtex-dev.atlassian.net/browse/LOC-22226), following [this thread](https://vtex.slack.com/archives/C052CEU8GDU/p1758631993501999) and @matheusfurtado96 and @jamesthethird guidance.

[LOC-22226]: https://vtex-dev.atlassian.net/browse/LOC-22226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ